### PR TITLE
Support interactive demos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Nir Soffer <nirsof@gail.com>
+# SPDX-FileCopyrightText: Nir Soffer <nirsof@gmail.com>
 # SPDX-License-Identifier: MIT
 
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -9,13 +9,31 @@ SPDX-License-Identifier: MIT
 [![Downloads per month](https://img.shields.io/pypi/dm/nohands)](https://pypi.python.org/pypi/nohands)
 [![MIT license](https://img.shields.io/pypi/l/nohands)](https://pypi.python.org/pypi/nohands)
 
-A little library for effortless demos.
+A little library and command line tool for effortless demos.
 
-![Example demo](https://i.imgur.com/dhQkaVj.gif)
+## Example - fully scripted demo
 
-To run the example demo:
+When you have a short demo that can be fully scripted and requires no
+interaction, you can scrip the entire demo in one python module.
 
-    python example.py
+[![asciicast](https://asciinema.org/a/633574.svg)](https://asciinema.org/a/633574)
+
+See `example.py` for details.
+
+## Example - interactive demo
+
+When you need an interactive demo - run one command, discuss the command
+and the output, then run the next command, you can create a demo yaml
+and interact with the demo with the `nh` tool.
+
+[![asciicast](https://asciinema.org/a/633578.svg)](https://asciinema.org/a/633578)
+
+## Example - navigating an interactive demo
+
+You can navigate in an interactive demo using the `--reset`, `--skip`,
+and `--previous` options.
+
+[![asciicast](https://asciinema.org/a/633581.svg)](https://asciinema.org/a/633581)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Nir Soffer <nirsof@gail.com>
+SPDX-FileCopyrightText: Nir Soffer <nirsof@gmail.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Nir Soffer <nirsof@gail.com>
+# SPDX-FileCopyrightText: Nir Soffer <nirsof@gmail.com>
 # SPDX-License-Identifier: MIT
 
 from nohands import *

--- a/nohands/__init__.py
+++ b/nohands/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Nir Soffer <nirsof@gail.com>
+# SPDX-FileCopyrightText: Nir Soffer <nirsof@gmail.com>
 # SPDX-License-Identifier: MIT
 
 import subprocess

--- a/nohands/__init__.py
+++ b/nohands/__init__.py
@@ -35,7 +35,7 @@ def show(args):
         if len(line) + len(arg) > 80:
             line += sep + "\\"
             msg(line, color=CYAN, prompt=prompt)
-            prompt = "> "
+            prompt = "      "
             line = sep = ""
         line += sep + arg
         sep = " "

--- a/nohands/__init__.py
+++ b/nohands/__init__.py
@@ -5,7 +5,7 @@ import subprocess
 import time
 
 __all__ = ["msg", "run", "GREEN", "CYAN", "YELLOW", "GREY"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 GREY = "\033[38;5;250m"
 GREEN = "\033[1;32m"
@@ -22,16 +22,18 @@ def msg(s="", color=GREEN, delay=0.1, char_delay=0.075, prompt="$ "):
     time.sleep(delay)
 
 
-def run(*args):
-    show(args)
+def run(*args, delay=0.1):
+    show(args, delay=delay)
     subprocess.run(args)
 
 
-def show(args):
+def show(args, delay=0.1):
     prompt = "$ "
     line = sep = ""
 
     for arg in args:
+        if " " in arg:
+            arg = "'" + arg + "'"
         if len(line) + len(arg) > 80:
             line += sep + "\\"
             msg(line, color=CYAN, prompt=prompt)
@@ -40,4 +42,4 @@ def show(args):
         line += sep + arg
         sep = " "
 
-    msg(line, color=CYAN, prompt=prompt)
+    msg(line, color=CYAN, prompt=prompt, delay=delay)

--- a/nohands/__main__.py
+++ b/nohands/__main__.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Nir Soffer <nirsof@gmail.com>
+# SPDX-License-Identifier: MIT
+
+import sys
+import argparse
+
+import nohands
+from nohands import demo
+
+
+def main():
+    p = argparse.ArgumentParser("nh")
+    p.add_argument("-r", "--reset", action="store_true", help="go to first step")
+    p.add_argument("-p", "--previous", action="store_true", help="go to previous step")
+    p.add_argument("-s", "--skip", action="store_true", help="skip current step")
+    p.add_argument("--init", action="store_true", help="create a new demo in the current directory")
+    args = p.parse_args()
+
+    if args.init:
+        init()
+    elif args.reset:
+        reset()
+    elif args.previous:
+        previous()
+    elif args.skip:
+        skip()
+    else:
+        run()
+
+
+def init():
+    demo.init()
+    print(f"Created new demo in {demo.BASE}")
+    sys.exit(0)
+
+
+def reset():
+    demo.reset()
+    step = demo.step(0)
+    print(f"Next: {step['name']}")
+    sys.exit(0)
+
+
+def previous():
+    previous = max(0, demo.current() - 1)
+    demo.advance(previous)
+    step = demo.step(previous)
+    print(f"Next: {step['name']}")
+    sys.exit(0)
+
+
+def skip():
+    current = demo.current()
+    step = demo.step(current + 1)
+    if step is None:
+        print(f"Next: [done]")
+    else:
+        demo.advance(current + 1)
+        print(f"Next: {step['name']}")
+    sys.exit(0)
+
+
+def run():
+    current = demo.current()
+    step = demo.step(current)
+    if step is None:
+        sys.exit("[done]")
+
+    demo.advance(current + 1)
+    nohands.msg(step["name"])
+    if "run" in step:
+        try:
+            nohands.run(*step["run"], delay=step["delay"])
+        except KeyboardInterrupt:
+            # Interrupting a command is not an error. Typical use case is to
+            # run "watch command ..." and interrupt the command when needed.
+            pass

--- a/nohands/demo.py
+++ b/nohands/demo.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Nir Soffer <nirsof@gmail.com>
+# SPDX-License-Identifier: MIT
+
+import os
+import yaml
+
+BASE = ".nh"
+CURRENT = os.path.join(BASE, "current")
+DEMO = os.path.join(BASE, "demo.yaml")
+
+SAMPLE = f"""\
+steps:
+  - name: "## My awesome demo!"
+    run: [tree, {BASE}]
+  - name: "## The demo yaml"
+    run: [cat, {DEMO}]
+  - name: "## The current file"
+    run: [cat, {CURRENT}]
+  - name: "Created with https://github.com/nirs/nohands/"
+options:
+  delay: 0.5
+"""
+
+def init():
+    os.makedirs(BASE, exist_ok=True)
+    advance(0)
+    if not os.path.exists(DEMO):
+        with open(DEMO, "w") as f:
+            f.write(SAMPLE)
+
+
+def current():
+    with open(CURRENT) as f:
+       return int(f.readline())
+
+
+def advance(n):
+    with open(CURRENT, "w") as f:
+        f.write(f"{n}\n")
+
+
+def reset():
+    advance(0)
+
+
+def step(n):
+    with open(DEMO) as f:
+        demo = yaml.safe_load(f)
+        try:
+            step = demo["steps"][n]
+        except IndexError:
+            return None
+        else:
+            if "delay" not in step:
+                step["delay"] = delay(demo)
+            return step
+
+
+def delay(demo):
+    return demo.get("options", {}).get("delay", 0.1)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     name="nohands",
     url="https://github.com/nirs/nohands",
     packages=["nohands"],
+    install_requires=["PyYAML"],
     project_urls={
         "Source": "https://github.com/nirs/nohands",
         "Bug Tracker": "https://github.com/nirs/nohands/issues",
@@ -30,4 +31,7 @@ setup(
         "Intended Audience :: Developers",
         "Topic :: Utilities",
     ],
+    entry_points={
+        "console_scripts": ["nh=nohands.__main__:main"],
+    },
 )


### PR DESCRIPTION
For longer demos we want to run a step, discuss the command and output, and sometimes 
watch a command and interrupt it when the command reach the wanted state.

This change adds the `nh` tool for running multi-step yaml based demos.